### PR TITLE
fix: allow header values to be arrays in `netlify.toml`

### DIFF
--- a/src/normalize.js
+++ b/src/normalize.js
@@ -72,12 +72,20 @@ const normalizeValue = function (rawKey, rawValue) {
     throw new Error('Empty header name')
   }
 
-  if (typeof rawValue !== 'string') {
-    throw new TypeError(`Header "${key}" value must be a string not: ${rawValue}`)
+  const value = normalizeRawValue(key, rawValue)
+  return [key, value]
+}
+
+const normalizeRawValue = function (key, rawValue) {
+  if (typeof rawValue === 'string') {
+    return normalizeMultipleValues(normalizeStringValue(rawValue))
   }
 
-  const value = normalizeMultipleValues(rawValue.trim())
-  return [key, value]
+  if (Array.isArray(rawValue)) {
+    return rawValue.map((singleValue, index) => normalizeArrayItemValue(`${key}[${index}]`, singleValue)).join(',')
+  }
+
+  throw new TypeError(`Header "${key}" value must be a string not: ${rawValue}`)
 }
 
 // Multiple values can be specified by using whitespaces and commas.
@@ -100,5 +108,17 @@ const normalizeMultipleValues = function (value) {
 }
 
 const MULTIPLE_VALUES_REGEXP = /\s*,\s*/g
+
+const normalizeArrayItemValue = function (key, singleValue) {
+  if (typeof singleValue !== 'string') {
+    throw new TypeError(`Header "${key}" value must be a string not: ${singleValue}`)
+  }
+
+  return normalizeStringValue(singleValue)
+}
+
+const normalizeStringValue = function (stringValue) {
+  return stringValue.trim()
+}
 
 module.exports = { normalizeHeaders }

--- a/tests/fixtures/netlify_config/invalid_value_array.toml
+++ b/tests/fixtures/netlify_config/invalid_value_array.toml
@@ -1,0 +1,4 @@
+[[headers]]
+for = "/path"
+  [headers.values]
+  test = [true]

--- a/tests/fixtures/netlify_config/trim_value_array.toml
+++ b/tests/fixtures/netlify_config/trim_value_array.toml
@@ -1,0 +1,4 @@
+[[headers]]
+for = "/path"
+  [headers.values]
+  test = [" one ", " two "]

--- a/tests/fixtures/netlify_config/value_array.toml
+++ b/tests/fixtures/netlify_config/value_array.toml
@@ -1,0 +1,4 @@
+[[headers]]
+for = "/path"
+  [headers.values]
+  test = ["one", "two"]

--- a/tests/netlify_config_parser.js
+++ b/tests/netlify_config_parser.js
@@ -37,12 +37,20 @@ each(
       output: [{ for: '/path', values: { test: 'one' } }],
     },
     {
+      title: 'trim_value_array',
+      output: [{ for: '/path', values: { test: 'one,two' } }],
+    },
+    {
       title: 'multiple_values',
       output: [{ for: '/path', values: { test: 'one,two' } }],
     },
     {
       title: 'values_undefined',
       output: [],
+    },
+    {
+      title: 'value_array',
+      output: [{ for: '/path', values: { test: 'one,two' } }],
     },
     {
       title: 'for_path_no_slash',
@@ -66,6 +74,7 @@ each(
     { title: 'invalid_values_object', errorMessage: /must be an object/ },
     { title: 'invalid_value_name', errorMessage: /Empty header name/ },
     { title: 'invalid_value_string', errorMessage: /must be a string/ },
+    { title: 'invalid_value_array', errorMessage: /must be a string/ },
   ],
   ({ title }, { fixtureName = title, errorMessage }) => {
     test(`Validate syntax errors | ${title}`, async (t) => {


### PR DESCRIPTION
Header values can be arrays in `netlify.toml`, although that behavior is undocumented.