### PR TITLE
feat!: add lenient parsing

### DIFF
--- a/src/all.js
+++ b/src/all.js
@@ -2,28 +2,37 @@ const { parseFileHeaders } = require('./line_parser')
 const { mergeHeaders } = require('./merge')
 const { parseConfigHeaders } = require('./netlify_config_parser')
 const { normalizeHeaders } = require('./normalize')
+const { splitResults, concatResults } = require('./results')
 
 // Parse all headers from `netlify.toml` and `_headers` file, then normalize
 // and validate those.
 const parseAllHeaders = async function ({ headersFiles = [], netlifyConfigPath } = {}) {
-  const [fileHeaders, configHeaders] = await Promise.all([
-    getFileHeaders(headersFiles),
-    getConfigHeaders(netlifyConfigPath),
-  ])
-  const normalizedFileHeaders = normalizeHeaders(fileHeaders)
-  const normalizedConfigHeaders = normalizeHeaders(configHeaders)
-  return mergeHeaders({ fileHeaders: normalizedFileHeaders, configHeaders: normalizedConfigHeaders })
+  const [{ headers: fileHeaders, errors: fileParseErrors }, { headers: configHeaders, errors: configParseErrors }] =
+    await Promise.all([getFileHeaders(headersFiles), getConfigHeaders(netlifyConfigPath)])
+  const { headers: normalizedFileHeaders, errors: fileNormalizeErrors } = normalizeHeaders(fileHeaders)
+  const { headers: normalizedConfigHeaders, errors: configNormalizeErrors } = normalizeHeaders(configHeaders)
+  const { headers, errors: mergeErrors } = mergeHeaders({
+    fileHeaders: normalizedFileHeaders,
+    configHeaders: normalizedConfigHeaders,
+  })
+  const errors = [
+    ...fileParseErrors,
+    ...fileNormalizeErrors,
+    ...configParseErrors,
+    ...configNormalizeErrors,
+    ...mergeErrors,
+  ]
+  return { headers, errors }
 }
 
 const getFileHeaders = async function (headersFiles) {
-  const fileHeaders = await Promise.all(headersFiles.map(parseFileHeaders))
-  // eslint-disable-next-line unicorn/prefer-spread
-  return [].concat(...fileHeaders)
+  const resultsArrays = await Promise.all(headersFiles.map(parseFileHeaders))
+  return concatResults(resultsArrays)
 }
 
 const getConfigHeaders = async function (netlifyConfigPath) {
   if (netlifyConfigPath === undefined) {
-    return []
+    return splitResults([])
   }
 
   return await parseConfigHeaders(netlifyConfigPath)

--- a/src/merge.js
+++ b/src/merge.js
@@ -15,14 +15,23 @@ const { inspect, isDeepStrictEqual } = require('util')
 //  - The same path is specified twice in `_headers`, the behavior is the same
 //    as `netlify.toml` headers.
 const mergeHeaders = function ({ fileHeaders = [], configHeaders = [] }) {
-  validateArray(fileHeaders)
-  validateArray(configHeaders)
-  return [...fileHeaders, ...configHeaders].filter(isUniqueHeader)
+  const errors = validateArrays(fileHeaders, configHeaders)
+  if (errors.length !== 0) {
+    return { headers: [], errors }
+  }
+  const headers = [...fileHeaders, ...configHeaders].filter(isUniqueHeader)
+  return { headers, errors: [] }
+}
+
+const validateArrays = function (fileHeaders, configHeaders) {
+  const fileError = validateArray(fileHeaders)
+  const configError = validateArray(configHeaders)
+  return [fileError, configError].filter(Boolean)
 }
 
 const validateArray = function (headers) {
   if (!Array.isArray(headers)) {
-    throw new TypeError(`Headers should be an array: ${inspect(headers, { colors: false })}`)
+    return new TypeError(`Headers should be an array: ${inspect(headers, { colors: false })}`)
   }
 }
 

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -1,26 +1,30 @@
 const isPlainObj = require('is-plain-obj')
 const mapObj = require('map-obj')
 
+const { splitResults } = require('./results')
+
 // Validate and normalize an array of `headers` objects.
 // This step is performed after `headers` have been parsed from either
 // `netlify.toml` or `_headerss`.
 const normalizeHeaders = function (headers) {
   if (!Array.isArray(headers)) {
-    throw new TypeError(`Headers must be an array not: ${headers}`)
+    const error = new TypeError(`Headers must be an array not: ${headers}`)
+    return splitResults([error])
   }
 
-  return headers.map(parseHeader).filter(Boolean)
+  const results = headers.map(parseHeader).filter(Boolean)
+  return splitResults(results)
 }
 
 const parseHeader = function (header, index) {
   if (!isPlainObj(header)) {
-    throw new TypeError(`Header must be an object not: ${header}`)
+    return new TypeError(`Header must be an object not: ${header}`)
   }
 
   try {
     return parseHeaderObject(header)
   } catch (error) {
-    throw new Error(`Could not parse header number ${index + 1}:
+    return new Error(`Could not parse header number ${index + 1}:
   ${JSON.stringify(header)}
 ${error.message}`)
   }

--- a/src/results.js
+++ b/src/results.js
@@ -1,0 +1,29 @@
+// If one header fails to parse, we still try to return the other ones
+const splitResults = function (results) {
+  const headers = results.filter((result) => !isError(result))
+  const errors = results.filter(isError)
+  return { headers, errors }
+}
+
+const isError = function (result) {
+  return result instanceof Error
+}
+
+// Concatenate an array of `{ headers, erors }`
+const concatResults = function (resultsArrays) {
+  // eslint-disable-next-line unicorn/prefer-spread
+  const headers = [].concat(...resultsArrays.map(getHeaders))
+  // eslint-disable-next-line unicorn/prefer-spread
+  const errors = [].concat(...resultsArrays.map(getErrors))
+  return { headers, errors }
+}
+
+const getHeaders = function ({ headers }) {
+  return headers
+}
+
+const getErrors = function ({ errors }) {
+  return errors
+}
+
+module.exports = { splitResults, concatResults }

--- a/tests/all.js
+++ b/tests/all.js
@@ -58,7 +58,9 @@ each(
   ],
   ({ title }, { fileFixtureNames, configFixtureName, output }) => {
     test(`Parses netlify.toml and _headers | ${title}`, async (t) => {
-      t.deepEqual(await parseHeaders({ fileFixtureNames, configFixtureName }), output)
+      const { headers, errors } = await parseHeaders({ fileFixtureNames, configFixtureName })
+      t.is(errors.length, 0)
+      t.deepEqual(headers, output)
     })
   },
 )

--- a/tests/merge.js
+++ b/tests/merge.js
@@ -111,8 +111,10 @@ each(
     },
   ],
   ({ title }, { fileHeaders, configHeaders, output }) => {
-    test(`Merges _headers with netlify.toml headers | ${title}`, (t) => {
-      t.deepEqual(mergeHeaders({ fileHeaders, configHeaders }), output)
+    test(`Merges _headers with netlify.toml headers | ${title}`, async (t) => {
+      const { headers, errors } = await mergeHeaders({ fileHeaders, configHeaders })
+      t.is(errors.length, 0)
+      t.deepEqual(headers, output)
     })
   },
 )
@@ -124,7 +126,10 @@ each(
   ],
   ({ title }, { fileHeaders, configHeaders, errorMessage }) => {
     test(`Validate syntax errors | ${title}`, async (t) => {
-      await t.throws(mergeHeaders.bind(undefined, { fileHeaders, configHeaders }), errorMessage)
+      const { headers, errors } = await mergeHeaders({ fileHeaders, configHeaders })
+      t.is(headers.length, 0)
+      // eslint-disable-next-line max-nested-callbacks
+      t.true(errors.some((error) => errorMessage.test(error.message)))
     })
   },
 )

--- a/tests/netlify_config_parser.js
+++ b/tests/netlify_config_parser.js
@@ -6,8 +6,11 @@ const { parseConfigHeaders, normalizeHeaders } = require('..')
 const FIXTURES_DIR = `${__dirname}/fixtures`
 
 const parseHeaders = async function (fixtureName) {
-  const headers = await parseConfigHeaders(`${FIXTURES_DIR}/netlify_config/${fixtureName}.toml`)
-  return normalizeHeaders(headers)
+  const { headers, errors: parseErrors } = await parseConfigHeaders(
+    `${FIXTURES_DIR}/netlify_config/${fixtureName}.toml`,
+  )
+  const { headers: normalizedHeaders, errors: normalizeErrors } = normalizeHeaders(headers)
+  return { headers: normalizedHeaders, errors: [...parseErrors, ...normalizeErrors] }
 }
 
 each(
@@ -59,7 +62,9 @@ each(
   ],
   ({ title }, { fixtureName = title, output }) => {
     test(`Parses netlify.toml headers | ${title}`, async (t) => {
-      t.deepEqual(await parseHeaders(fixtureName), output)
+      const { headers, errors } = await parseHeaders(fixtureName)
+      t.is(errors.length, 0)
+      t.deepEqual(headers, output)
     })
   },
 )
@@ -78,7 +83,10 @@ each(
   ],
   ({ title }, { fixtureName = title, errorMessage }) => {
     test(`Validate syntax errors | ${title}`, async (t) => {
-      await t.throwsAsync(parseHeaders(fixtureName), errorMessage)
+      const { headers, errors } = await parseHeaders(fixtureName)
+      t.is(headers.length, 0)
+      // eslint-disable-next-line max-nested-callbacks
+      t.true(errors.some((error) => errorMessage.test(error.message)))
     })
   },
 )


### PR DESCRIPTION
In production, when a specific header in either `_headers` or `netlify.toml` has some syntax error, that header is ignored but we still parse the other headers. However, this library throws instead.

This PR brings the production behavior, so: 
  - The CLI behavior matches it (as part of the world-class local development initiative). 
  - `netlifyConfig.headers` modifications match it (as part of https://github.com/netlify/build/issues/1193)

It does so by making all methods return an object `{ headers, errors }` instead of a single array `heades`. `errors` is an array of error instances.

Sibling PR for redirects parsing: https://github.com/netlify/netlify-redirect-parser/pull/314