### PR TITLE
feat: add `configHeaders` argument to `parseAllHeaders()`

### DIFF
--- a/src/all.js
+++ b/src/all.js
@@ -6,19 +6,24 @@ const { splitResults, concatResults } = require('./results')
 
 // Parse all headers from `netlify.toml` and `_headers` file, then normalize
 // and validate those.
-const parseAllHeaders = async function ({ headersFiles = [], netlifyConfigPath } = {}) {
-  const [{ headers: fileHeaders, errors: fileParseErrors }, { headers: configHeaders, errors: configParseErrors }] =
-    await Promise.all([getFileHeaders(headersFiles), getConfigHeaders(netlifyConfigPath)])
+const parseAllHeaders = async function ({ headersFiles = [], netlifyConfigPath, configHeaders = [] } = {}) {
+  const [
+    { headers: fileHeaders, errors: fileParseErrors },
+    { headers: parsedConfigHeaders, errors: configParseErrors },
+  ] = await Promise.all([getFileHeaders(headersFiles), getConfigHeaders(netlifyConfigPath)])
   const { headers: normalizedFileHeaders, errors: fileNormalizeErrors } = normalizeHeaders(fileHeaders)
+  const { headers: normalizedConfigParseHeaders, errors: configParseNormalizeErrors } =
+    normalizeHeaders(parsedConfigHeaders)
   const { headers: normalizedConfigHeaders, errors: configNormalizeErrors } = normalizeHeaders(configHeaders)
   const { headers, errors: mergeErrors } = mergeHeaders({
     fileHeaders: normalizedFileHeaders,
-    configHeaders: normalizedConfigHeaders,
+    configHeaders: [...normalizedConfigParseHeaders, ...normalizedConfigHeaders],
   })
   const errors = [
     ...fileParseErrors,
     ...fileNormalizeErrors,
     ...configParseErrors,
+    ...configParseNormalizeErrors,
     ...configNormalizeErrors,
     ...mergeErrors,
   ]

--- a/tests/all.js
+++ b/tests/all.js
@@ -5,16 +5,21 @@ const { parseAllHeaders } = require('..')
 
 const FIXTURES_DIR = `${__dirname}/fixtures`
 
-const parseHeaders = async function ({ fileFixtureNames, configFixtureName }) {
+const parseHeaders = async function ({ fileFixtureNames, configFixtureName, configHeaders }) {
   const headersFiles =
     fileFixtureNames === undefined
       ? undefined
       : fileFixtureNames.map((fileFixtureName) => `${FIXTURES_DIR}/headers_file/${fileFixtureName}`)
   const netlifyConfigPath =
     configFixtureName === undefined ? undefined : `${FIXTURES_DIR}/netlify_config/${configFixtureName}.toml`
-  const options =
-    headersFiles === undefined && netlifyConfigPath === undefined ? undefined : { headersFiles, netlifyConfigPath }
+  const options = getOptions({ headersFiles, netlifyConfigPath, configHeaders })
   return await parseAllHeaders(options)
+}
+
+const getOptions = function ({ headersFiles, netlifyConfigPath, configHeaders }) {
+  return headersFiles === undefined && netlifyConfigPath === undefined && configHeaders === undefined
+    ? undefined
+    : { headersFiles, netlifyConfigPath, configHeaders }
 }
 
 each(
@@ -46,6 +51,15 @@ each(
       ],
     },
     {
+      title: 'config_headers',
+      configFixtureName: 'success',
+      configHeaders: [{ for: '/path', values: { test: ' two ' } }],
+      output: [
+        { for: '/path', values: { test: 'one' } },
+        { for: '/path', values: { test: 'two' } },
+      ],
+    },
+    {
       title: 'duplicates',
       fileFixtureNames: ['duplicate'],
       configFixtureName: 'duplicate',
@@ -56,9 +70,9 @@ each(
       ],
     },
   ],
-  ({ title }, { fileFixtureNames, configFixtureName, output }) => {
+  ({ title }, { fileFixtureNames, configFixtureName, configHeaders, output }) => {
     test(`Parses netlify.toml and _headers | ${title}`, async (t) => {
-      const { headers, errors } = await parseHeaders({ fileFixtureNames, configFixtureName })
+      const { headers, errors } = await parseHeaders({ fileFixtureNames, configFixtureName, configHeaders })
       t.is(errors.length, 0)
       t.deepEqual(headers, output)
     })


### PR DESCRIPTION
Part of https://github.com/netlify/build/issues/2890

This adds a `configHeaders` argument to `parseAllHeaders()` to pass headers programmatically instead of specifying a `netlify.toml` path. 

This would be useful for `@netlify/config` since it has already parsed `netlify.toml` and does not need to parse it again. This will allow `@netlify/config` to switch to using `parseAllHeaders()` instead of each method exported by `netlify-headers-parser`.