### PR TITLE
feat!: simplify exported methods

### DIFF
--- a/src/all.js
+++ b/src/all.js
@@ -6,7 +6,7 @@ const { splitResults, concatResults } = require('./results')
 
 // Parse all headers from `netlify.toml` and `_headers` file, then normalize
 // and validate those.
-const parseAllHeaders = async function ({ headersFiles = [], netlifyConfigPath, configHeaders = [] } = {}) {
+const parseAllHeaders = async function ({ headersFiles = [], netlifyConfigPath, configHeaders = [] }) {
   const [
     { headers: fileHeaders, errors: fileParseErrors },
     { headers: parsedConfigHeaders, errors: configParseErrors },

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,3 @@
 const { parseAllHeaders } = require('./all')
-const { parseFileHeaders } = require('./line_parser')
-const { mergeHeaders } = require('./merge')
-const { parseConfigHeaders } = require('./netlify_config_parser')
-const { normalizeHeaders } = require('./normalize')
 
-module.exports = {
-  parseAllHeaders,
-  parseFileHeaders,
-  mergeHeaders,
-  parseConfigHeaders,
-  normalizeHeaders,
-}
+module.exports = { parseAllHeaders }

--- a/src/merge.js
+++ b/src/merge.js
@@ -1,4 +1,4 @@
-const { inspect, isDeepStrictEqual } = require('util')
+const { isDeepStrictEqual } = require('util')
 
 const { splitResults } = require('./results')
 
@@ -16,17 +16,11 @@ const { splitResults } = require('./results')
 //    path, it is concatenated as a comma-separated list string.
 //  - The same path is specified twice in `_headers`, the behavior is the same
 //    as `netlify.toml` headers.
-const mergeHeaders = function ({ fileHeaders = [], configHeaders = [] }) {
-  const results = [...validateArray(fileHeaders), ...validateArray(configHeaders)]
+const mergeHeaders = function ({ fileHeaders, configHeaders }) {
+  const results = [...fileHeaders, ...configHeaders]
   const { headers, errors } = splitResults(results)
   const mergedHeaders = headers.filter(isUniqueHeader)
   return { headers: mergedHeaders, errors }
-}
-
-const validateArray = function (headers) {
-  return Array.isArray(headers)
-    ? headers
-    : [new TypeError(`Headers should be an array: ${inspect(headers, { colors: false })}`)]
 }
 
 // Remove duplicates. This is especially likely considering `fileHeaders` might

--- a/tests/all.js
+++ b/tests/all.js
@@ -12,14 +12,7 @@ const parseHeaders = async function ({ fileFixtureNames, configFixtureName, conf
       : fileFixtureNames.map((fileFixtureName) => `${FIXTURES_DIR}/headers_file/${fileFixtureName}`)
   const netlifyConfigPath =
     configFixtureName === undefined ? undefined : `${FIXTURES_DIR}/netlify_config/${configFixtureName}.toml`
-  const options = getOptions({ headersFiles, netlifyConfigPath, configHeaders })
-  return await parseAllHeaders(options)
-}
-
-const getOptions = function ({ headersFiles, netlifyConfigPath, configHeaders }) {
-  return headersFiles === undefined && netlifyConfigPath === undefined && configHeaders === undefined
-    ? undefined
-    : { headersFiles, netlifyConfigPath, configHeaders }
+  return await parseAllHeaders({ headersFiles, netlifyConfigPath, configHeaders })
 }
 
 each(

--- a/tests/line_parser.js
+++ b/tests/line_parser.js
@@ -1,7 +1,8 @@
 const test = require('ava')
 const { each } = require('test-each')
 
-const { parseFileHeaders, normalizeHeaders } = require('..')
+const { parseFileHeaders } = require('../src/line_parser')
+const { normalizeHeaders } = require('../src/normalize')
 
 const FIXTURES_DIR = `${__dirname}/fixtures`
 

--- a/tests/merge.js
+++ b/tests/merge.js
@@ -1,11 +1,10 @@
 const test = require('ava')
 const { each } = require('test-each')
 
-const { mergeHeaders } = require('..')
+const { mergeHeaders } = require('../src/merge')
 
 each(
   [
-    { output: [] },
     { fileHeaders: [], configHeaders: [], output: [] },
     {
       fileHeaders: [
@@ -115,21 +114,6 @@ each(
       const { headers, errors } = await mergeHeaders({ fileHeaders, configHeaders })
       t.is(errors.length, 0)
       t.deepEqual(headers, output)
-    })
-  },
-)
-
-each(
-  [
-    { fileHeaders: { for: true }, errorMessage: /should be an array/ },
-    { configHeaders: { for: true }, errorMessage: /should be an array/ },
-  ],
-  ({ title }, { fileHeaders, configHeaders, errorMessage }) => {
-    test(`Validate syntax errors | ${title}`, async (t) => {
-      const { headers, errors } = await mergeHeaders({ fileHeaders, configHeaders })
-      t.is(headers.length, 0)
-      // eslint-disable-next-line max-nested-callbacks
-      t.true(errors.some((error) => errorMessage.test(error.message)))
     })
   },
 )

--- a/tests/netlify_config_parser.js
+++ b/tests/netlify_config_parser.js
@@ -1,7 +1,8 @@
 const test = require('ava')
 const { each } = require('test-each')
 
-const { parseConfigHeaders, normalizeHeaders } = require('..')
+const { parseConfigHeaders } = require('../src/netlify_config_parser')
+const { normalizeHeaders } = require('../src/normalize')
 
 const FIXTURES_DIR = `${__dirname}/fixtures`
 


### PR DESCRIPTION
Now that `@netlify/config` only uses the `parseAllHeaders()` method (see https://github.com/netlify/build/pull/3468), we can export only that method. This will simplify maintaining this module and will keep its API smaller.

Sibling PR for redirects: https://github.com/netlify/netlify-redirect-parser/pull/318