### PR TITLE
chore: simplify tests

### DIFF
--- a/tests/helpers/main.js
+++ b/tests/helpers/main.js
@@ -1,0 +1,34 @@
+const { parseAllHeaders } = require('../..')
+
+const FIXTURES_DIR = `${__dirname}/../fixtures`
+
+// Pass an `input` to the main method and assert its output
+const validateSuccess = async function (t, { input, output }) {
+  const { headers } = await parseHeaders(input)
+  t.deepEqual(headers, output)
+}
+
+// Pass an `input` to the main method and assert it fails with a specific error
+const validateError = async function (t, { input, errorMessage }) {
+  const { errors } = await parseHeaders(input)
+  t.not(errors.length, 0)
+  t.true(errors.some((error) => errorMessage.test(error.message)))
+}
+
+const parseHeaders = async function ({ headersFiles, netlifyConfigPath, configHeaders }) {
+  return await parseAllHeaders({
+    ...(headersFiles && { headersFiles: headersFiles.map(addFileFixtureDir) }),
+    ...(netlifyConfigPath && { netlifyConfigPath: addConfigFixtureDir(netlifyConfigPath) }),
+    configHeaders,
+  })
+}
+
+const addFileFixtureDir = function (name) {
+  return `${FIXTURES_DIR}/headers_file/${name}`
+}
+
+const addConfigFixtureDir = function (name) {
+  return `${FIXTURES_DIR}/netlify_config/${name}.toml`
+}
+
+module.exports = { validateSuccess, validateError }

--- a/tests/line_parser.js
+++ b/tests/line_parser.js
@@ -1,85 +1,122 @@
 const test = require('ava')
 const { each } = require('test-each')
 
-const { parseFileHeaders } = require('../src/line_parser')
-const { normalizeHeaders } = require('../src/normalize')
-
-const FIXTURES_DIR = `${__dirname}/fixtures`
-
-const parseHeaders = async function (fixtureName) {
-  const { headers, errors: parseErrors } = await parseFileHeaders(`${FIXTURES_DIR}/headers_file/${fixtureName}`)
-  const { headers: normalizedHeaders, errors: normalizeErrors } = normalizeHeaders(headers)
-  return { headers: normalizedHeaders, errors: [...parseErrors, ...normalizeErrors] }
-}
+const { validateSuccess, validateError } = require('./helpers/main')
 
 each(
   [
     {
       title: 'empty',
+      input: {
+        headersFiles: ['empty'],
+      },
       output: [],
     },
     {
       title: 'non_existing',
+      input: {
+        headersFiles: ['non_existing'],
+      },
       output: [],
     },
     {
       title: 'trim_line_path',
+      input: {
+        headersFiles: ['trim_line_path'],
+      },
       output: [],
     },
     {
       title: 'trim_line_values',
+      input: {
+        headersFiles: ['trim_line_values'],
+      },
       output: [{ for: '/path', values: { test: 'one' } }],
     },
     {
       title: 'empty_line',
+      input: {
+        headersFiles: ['empty_line'],
+      },
       output: [{ for: '/path', values: { test: 'one' } }],
     },
     {
       title: 'comment',
+      input: {
+        headersFiles: ['comment'],
+      },
       output: [{ for: '/path', values: { test: 'one' } }],
     },
     {
       title: 'success',
+      input: {
+        headersFiles: ['success'],
+      },
       output: [{ for: '/path', values: { test: 'one' } }],
     },
     {
       title: 'no_colon',
+      input: {
+        headersFiles: ['no_colon'],
+      },
       output: [],
     },
     {
       title: 'trim_name',
+      input: {
+        headersFiles: ['trim_name'],
+      },
       output: [{ for: '/path', values: { test: 'one' } }],
     },
     {
       title: 'trim_value',
+      input: {
+        headersFiles: ['trim_value'],
+      },
       output: [{ for: '/path', values: { test: 'one' } }],
     },
     {
       title: 'multiple_values',
+      input: {
+        headersFiles: ['multiple_values'],
+      },
       output: [{ for: '/path', values: { test: 'one,two' } }],
     },
   ],
-  ({ title }, { fixtureName = title, output }) => {
+  ({ title }, { output, input }) => {
     test(`Parses _headers | ${title}`, async (t) => {
-      const { headers, errors } = await parseHeaders(fixtureName)
-      t.is(errors.length, 0)
-      t.deepEqual(headers, output)
+      await validateSuccess(t, { input, output })
     })
   },
 )
 
 each(
   [
-    { title: 'invalid_value_name', errorMessage: /Missing header name/ },
-    { title: 'invalid_value_string', errorMessage: /Missing header value/ },
-    { title: 'invalid_for_order', errorMessage: /Path should come before/ },
+    {
+      title: 'invalid_value_name',
+      input: {
+        headersFiles: ['invalid_value_name'],
+      },
+      errorMessage: /Missing header name/,
+    },
+    {
+      title: 'invalid_value_string',
+      input: {
+        headersFiles: ['invalid_value_string'],
+      },
+      errorMessage: /Missing header value/,
+    },
+    {
+      title: 'invalid_for_order',
+      input: {
+        headersFiles: ['invalid_for_order'],
+      },
+      errorMessage: /Path should come before/,
+    },
   ],
-  ({ title }, { fixtureName = title, errorMessage }) => {
+  ({ title }, { errorMessage, input }) => {
     test(`Validate syntax errors | ${title}`, async (t) => {
-      const { headers, errors } = await parseHeaders(fixtureName)
-      t.is(headers.length, 0)
-      // eslint-disable-next-line max-nested-callbacks
-      t.true(errors.some((error) => errorMessage.test(error.message)))
+      await validateError(t, { input, errorMessage })
     })
   },
 )

--- a/tests/merge.js
+++ b/tests/merge.js
@@ -1,19 +1,21 @@
 const test = require('ava')
 const { each } = require('test-each')
 
-const { mergeHeaders } = require('../src/merge')
+const { validateSuccess } = require('./helpers/main')
 
 each(
   [
-    { fileHeaders: [], configHeaders: [], output: [] },
     {
-      fileHeaders: [
-        {
-          for: '/path',
-          values: { test: 'one' },
-        },
-      ],
-      configHeaders: [],
+      title: 'empty',
+      input: {},
+      output: [],
+    },
+    {
+      title: 'file_only',
+      input: {
+        headersFiles: ['success'],
+        configHeaders: [],
+      },
       output: [
         {
           for: '/path',
@@ -22,13 +24,15 @@ each(
       ],
     },
     {
-      fileHeaders: [],
-      configHeaders: [
-        {
-          for: '/pathTwo',
-          values: { testTwo: 'two' },
-        },
-      ],
+      title: 'config_only',
+      input: {
+        configHeaders: [
+          {
+            for: '/pathTwo',
+            values: { testTwo: 'two' },
+          },
+        ],
+      },
       output: [
         {
           for: '/pathTwo',
@@ -37,18 +41,16 @@ each(
       ],
     },
     {
-      fileHeaders: [
-        {
-          for: '/path',
-          values: { test: 'one' },
-        },
-      ],
-      configHeaders: [
-        {
-          for: '/pathTwo',
-          values: { testTwo: 'two' },
-        },
-      ],
+      title: 'both',
+      input: {
+        headersFiles: ['success'],
+        configHeaders: [
+          {
+            for: '/pathTwo',
+            values: { testTwo: 'two' },
+          },
+        ],
+      },
       output: [
         {
           for: '/path',
@@ -61,18 +63,16 @@ each(
       ],
     },
     {
-      fileHeaders: [
-        {
-          for: '/path',
-          values: { test: 'one' },
-        },
-      ],
-      configHeaders: [
-        {
-          for: '/path',
-          values: { testTwo: 'two' },
-        },
-      ],
+      title: 'both_same_path',
+      input: {
+        headersFiles: ['success'],
+        configHeaders: [
+          {
+            for: '/path',
+            values: { testTwo: 'two' },
+          },
+        ],
+      },
       output: [
         {
           for: '/path',
@@ -85,18 +85,16 @@ each(
       ],
     },
     {
-      fileHeaders: [
-        {
-          for: '/path',
-          values: { test: 'one' },
-        },
-      ],
-      configHeaders: [
-        {
-          for: '/path',
-          values: { test: 'two' },
-        },
-      ],
+      title: 'both_same_path_value',
+      input: {
+        headersFiles: ['success'],
+        configHeaders: [
+          {
+            for: '/path',
+            values: { test: 'two' },
+          },
+        ],
+      },
       output: [
         {
           for: '/path',
@@ -109,11 +107,9 @@ each(
       ],
     },
   ],
-  ({ title }, { fileHeaders, configHeaders, output }) => {
+  ({ title }, { output, input }) => {
     test(`Merges _headers with netlify.toml headers | ${title}`, async (t) => {
-      const { headers, errors } = await mergeHeaders({ fileHeaders, configHeaders })
-      t.is(errors.length, 0)
-      t.deepEqual(headers, output)
+      await validateSuccess(t, { input, output })
     })
   },
 )

--- a/tests/netlify_config_parser.js
+++ b/tests/netlify_config_parser.js
@@ -1,93 +1,164 @@
 const test = require('ava')
 const { each } = require('test-each')
 
-const { parseConfigHeaders } = require('../src/netlify_config_parser')
-const { normalizeHeaders } = require('../src/normalize')
-
-const FIXTURES_DIR = `${__dirname}/fixtures`
-
-const parseHeaders = async function (fixtureName) {
-  const { headers, errors: parseErrors } = await parseConfigHeaders(
-    `${FIXTURES_DIR}/netlify_config/${fixtureName}.toml`,
-  )
-  const { headers: normalizedHeaders, errors: normalizeErrors } = normalizeHeaders(headers)
-  return { headers: normalizedHeaders, errors: [...parseErrors, ...normalizeErrors] }
-}
+const { validateSuccess, validateError } = require('./helpers/main')
 
 each(
   [
     {
       title: 'empty',
+      input: {
+        netlifyConfigPath: 'empty',
+      },
       output: [],
     },
     {
       title: 'non_existing',
+      input: {
+        netlifyConfigPath: 'non_existing',
+      },
       output: [],
     },
     {
       title: 'success',
+      input: {
+        netlifyConfigPath: 'success',
+      },
       output: [{ for: '/path', values: { test: 'one' } }],
     },
     {
       title: 'trim_path',
+      input: {
+        netlifyConfigPath: 'trim_path',
+      },
       output: [{ for: '/path', values: { test: 'one' } }],
     },
     {
       title: 'trim_name',
+      input: {
+        netlifyConfigPath: 'trim_name',
+      },
       output: [{ for: '/path', values: { test: 'one' } }],
     },
     {
       title: 'trim_value',
+      input: {
+        netlifyConfigPath: 'trim_value',
+      },
       output: [{ for: '/path', values: { test: 'one' } }],
     },
     {
       title: 'trim_value_array',
+      input: {
+        netlifyConfigPath: 'trim_value_array',
+      },
       output: [{ for: '/path', values: { test: 'one,two' } }],
     },
     {
       title: 'multiple_values',
+      input: {
+        netlifyConfigPath: 'multiple_values',
+      },
       output: [{ for: '/path', values: { test: 'one,two' } }],
     },
     {
       title: 'values_undefined',
+      input: {
+        netlifyConfigPath: 'values_undefined',
+      },
       output: [],
     },
     {
       title: 'value_array',
+      input: {
+        netlifyConfigPath: 'value_array',
+      },
       output: [{ for: '/path', values: { test: 'one,two' } }],
     },
     {
       title: 'for_path_no_slash',
+      input: {
+        netlifyConfigPath: 'for_path_no_slash',
+      },
       output: [{ for: 'path', values: { test: 'one' } }],
     },
   ],
-  ({ title }, { fixtureName = title, output }) => {
+  ({ title }, { output, input }) => {
     test(`Parses netlify.toml headers | ${title}`, async (t) => {
-      const { headers, errors } = await parseHeaders(fixtureName)
-      t.is(errors.length, 0)
-      t.deepEqual(headers, output)
+      await validateSuccess(t, { input, output })
     })
   },
 )
 
 each(
   [
-    { title: 'invalid_toml', errorMessage: /parse configuration file/ },
-    { title: 'invalid_array', errorMessage: /must be an array/ },
-    { title: 'invalid_object', errorMessage: /must be an object/ },
-    { title: 'invalid_for_undefined', errorMessage: /Missing "for"/ },
-    { title: 'invalid_for_string', errorMessage: /must be a string/ },
-    { title: 'invalid_values_object', errorMessage: /must be an object/ },
-    { title: 'invalid_value_name', errorMessage: /Empty header name/ },
-    { title: 'invalid_value_string', errorMessage: /must be a string/ },
-    { title: 'invalid_value_array', errorMessage: /must be a string/ },
+    {
+      title: 'invalid_toml',
+      input: {
+        netlifyConfigPath: 'invalid_toml',
+      },
+      errorMessage: /parse configuration file/,
+    },
+    {
+      title: 'invalid_array',
+      input: {
+        netlifyConfigPath: 'invalid_array',
+      },
+      errorMessage: /must be an array/,
+    },
+    {
+      title: 'invalid_object',
+      input: {
+        netlifyConfigPath: 'invalid_object',
+      },
+      errorMessage: /must be an object/,
+    },
+    {
+      title: 'invalid_for_undefined',
+      input: {
+        netlifyConfigPath: 'invalid_for_undefined',
+      },
+      errorMessage: /Missing "for"/,
+    },
+    {
+      title: 'invalid_for_string',
+      input: {
+        netlifyConfigPath: 'invalid_for_string',
+      },
+      errorMessage: /must be a string/,
+    },
+    {
+      title: 'invalid_values_object',
+      input: {
+        netlifyConfigPath: 'invalid_values_object',
+      },
+      errorMessage: /must be an object/,
+    },
+    {
+      title: 'invalid_value_name',
+      input: {
+        netlifyConfigPath: 'invalid_value_name',
+      },
+      errorMessage: /Empty header name/,
+    },
+    {
+      title: 'invalid_value_string',
+      input: {
+        netlifyConfigPath: 'invalid_value_string',
+      },
+      errorMessage: /must be a string/,
+    },
+    {
+      title: 'invalid_value_array',
+      input: {
+        netlifyConfigPath: 'invalid_value_array',
+      },
+      errorMessage: /must be a string/,
+    },
   ],
-  ({ title }, { fixtureName = title, errorMessage }) => {
+  ({ title }, { errorMessage, input }) => {
     test(`Validate syntax errors | ${title}`, async (t) => {
-      const { headers, errors } = await parseHeaders(fixtureName)
-      t.is(headers.length, 0)
-      // eslint-disable-next-line max-nested-callbacks
-      t.true(errors.some((error) => errorMessage.test(error.message)))
+      await validateError(t, { input, errorMessage })
     })
   },
 )


### PR DESCRIPTION
This is a full refactoring of the tests, simplifying them thanks to https://github.com/netlify/netlify-headers-parser/pull/13
The test coverage is kept at 100%.

Sibling PR for redirects at https://github.com/netlify/netlify-redirect-parser/pull/320