### PR TITLE
chore: update `renovate.json5`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,5 +3,20 @@
   ignorePresets: [':prHourlyLimit2'],
   semanticCommits: true,
   dependencyDashboard: true,
-  packageRules: [],
+  packageRules: [
+    // Those cannot be upgraded until we drop support for Node 10 and
+    // use ES modules
+    {
+      matchPackageNames: ['is-plain-obj'],
+      allowedVersions: '<4',
+    },
+    {
+      matchPackageNames: ['path-exists'],
+      allowedVersions: '<5',
+    },
+    {
+      matchPackageNames: ['test-each'],
+      allowedVersions: '<3',
+    },
+  ],
 }


### PR DESCRIPTION
This adds more packages to ignore to `renovate.json5`