### PR TITLE
fix: handle `_headers` with wrong file type

### DIFF
--- a/tests/line_parser.js
+++ b/tests/line_parser.js
@@ -93,6 +93,13 @@ each(
 each(
   [
     {
+      title: 'invalid_dir',
+      input: {
+        headersFiles: ['invalid_dir'],
+      },
+      errorMessage: /read headers file/,
+    },
+    {
       title: 'invalid_value_name',
       input: {
         headersFiles: ['invalid_value_name'],


### PR DESCRIPTION
We should handle the case where `_headers` is a directory (which is invalid).

Sibling PR for redirects: https://github.com/netlify/netlify-redirect-parser/pull/327