### PR TITLE
feat!: add `forRegExp` property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
+        "escape-string-regexp": "^4.0.0",
         "is-plain-obj": "^3.0.0",
         "map-obj": "^4.2.1",
         "path-exists": "^4.0.0",
@@ -3075,7 +3076,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -11439,8 +11439,7 @@
     "escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
     },
     "eslint": {
       "version": "7.32.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "author": "Netlify",
   "license": "MIT",
   "dependencies": {
+    "escape-string-regexp": "^4.0.0",
     "is-plain-obj": "^3.0.0",
     "map-obj": "^4.2.1",
     "path-exists": "^4.0.0",

--- a/src/all.js
+++ b/src/all.js
@@ -6,15 +6,17 @@ const { splitResults, concatResults } = require('./results')
 
 // Parse all headers from `netlify.toml` and `_headers` file, then normalize
 // and validate those.
-const parseAllHeaders = async function ({ headersFiles = [], netlifyConfigPath, configHeaders = [] }) {
+const parseAllHeaders = async function ({ headersFiles = [], netlifyConfigPath, configHeaders = [], minimal = false }) {
   const [
     { headers: fileHeaders, errors: fileParseErrors },
     { headers: parsedConfigHeaders, errors: configParseErrors },
   ] = await Promise.all([getFileHeaders(headersFiles), getConfigHeaders(netlifyConfigPath)])
-  const { headers: normalizedFileHeaders, errors: fileNormalizeErrors } = normalizeHeaders(fileHeaders)
-  const { headers: normalizedConfigParseHeaders, errors: configParseNormalizeErrors } =
-    normalizeHeaders(parsedConfigHeaders)
-  const { headers: normalizedConfigHeaders, errors: configNormalizeErrors } = normalizeHeaders(configHeaders)
+  const { headers: normalizedFileHeaders, errors: fileNormalizeErrors } = normalizeHeaders(fileHeaders, minimal)
+  const { headers: normalizedConfigParseHeaders, errors: configParseNormalizeErrors } = normalizeHeaders(
+    parsedConfigHeaders,
+    minimal,
+  )
+  const { headers: normalizedConfigHeaders, errors: configNormalizeErrors } = normalizeHeaders(configHeaders, minimal)
   const { headers, errors: mergeErrors } = mergeHeaders({
     fileHeaders: normalizedFileHeaders,
     configHeaders: [...normalizedConfigParseHeaders, ...normalizedConfigHeaders],

--- a/src/for_regexp.js
+++ b/src/for_regexp.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const escapeStringRegExp = require('escape-string-regexp')
+
+// Retrieve `forRegExp` which is a `RegExp` used to match the `for` path
+const getForRegExp = function (forPath) {
+  const pattern = forPath.split('/').map(trimString).filter(Boolean).map(getPartRegExp).join('/')
+  return new RegExp(`^/${pattern}/?$`, 'iu')
+}
+
+const trimString = function (part) {
+  return part.trimEnd()
+}
+
+const getPartRegExp = function (part) {
+  // Placeholder like `/segment/:placeholder/test`
+  // Matches everything up to a /
+  if (part.startsWith(':')) {
+    return '([^/]+)'
+  }
+
+  // Standalone catch-all wildcard like `/segment/*`
+  // Unlike `:placeholder`, the whole part is optional
+  if (part === '*') {
+    return '?(.*)'
+  }
+
+  // Non-standalone catch-all wildcard like `/segment/hello*world/test`
+  if (part.includes('*')) {
+    // @todo use `part.replaceAll('*', ...)` after dropping support for
+    // Node <15.0.0
+    return part.replace(CATCH_ALL_CHAR_REGEXP, '(.*)')
+  }
+
+  return escapeStringRegExp(part)
+}
+
+const CATCH_ALL_CHAR_REGEXP = /\*/g
+
+module.exports = { getForRegExp }

--- a/tests/for_regexp.js
+++ b/tests/for_regexp.js
@@ -1,0 +1,35 @@
+const test = require('ava')
+const { each } = require('test-each')
+
+const { validateSuccess } = require('./helpers/main')
+
+each(
+  [
+    { title: 'empty', for: '', forRegExp: /^\/\/?$/iu },
+    { title: 'single_slash', for: '/', forRegExp: /^\/\/?$/iu },
+    { title: 'whitespaces', for: '/ /', forRegExp: /^\/\/?$/iu },
+    { title: 'trim_end', for: '/a ', forRegExp: /^\/a\/?$/iu },
+    { title: 'trim_start', for: '/ a', forRegExp: /^\/ a\/?$/iu },
+    { title: 'several_characters', for: 'abc', forRegExp: /^\/abc\/?$/iu },
+    { title: 'placeholder', for: '/a/:b', forRegExp: /^\/a\/([^/]+)\/?$/iu },
+    { title: 'wildcard_single', for: '*', forRegExp: /^\/?(.*)\/?$/iu },
+    { title: 'wildcard_slash', for: '/*', forRegExp: /^\/?(.*)\/?$/iu },
+    { title: 'wildcard_append', for: '/*/a', forRegExp: /^\/?(.*)\/a\/?$/iu },
+    { title: 'wildcard_prepend', for: '/a/*', forRegExp: /^\/a\/?(.*)\/?$/iu },
+    { title: 'wildcard_surround', for: '/a/*/b', forRegExp: /^\/a\/?(.*)\/b\/?$/iu },
+    { title: 'wildcard_multiple', for: '/a/*/*', forRegExp: /^\/a\/?(.*)\/?(.*)\/?$/iu },
+    { title: 'wildcard_inside', for: '/a/b*c', forRegExp: /^\/a\/b(.*)c\/?$/iu },
+    { title: 'trailing_slash', for: '/a/', forRegExp: /^\/a\/?$/iu },
+    { title: 'regexp_escape', for: '/a.', forRegExp: /^\/a\.\/?$/iu },
+    { title: 'double_slash_single', for: '//', forRegExp: /^\/\/?$/iu },
+    { title: 'double_slash_multiple', for: '//a//b//', forRegExp: /^\/a\/b\/?$/iu },
+  ],
+  ({ title }, { for: forPath, forRegExp }) => {
+    test(`Add forRegExp when minimal is false | ${title}`, async (t) => {
+      await validateSuccess(t, {
+        input: { configHeaders: [{ for: forPath, values: { test: 'one' } }], minimal: undefined },
+        output: [{ for: forPath.trim(), forRegExp, values: { test: 'one' } }],
+      })
+    })
+  },
+)

--- a/tests/helpers/main.js
+++ b/tests/helpers/main.js
@@ -15,11 +15,14 @@ const validateError = async function (t, { input, errorMessage }) {
   t.true(errors.some((error) => errorMessage.test(error.message)))
 }
 
-const parseHeaders = async function ({ headersFiles, netlifyConfigPath, configHeaders }) {
+const parseHeaders = async function ({ headersFiles, netlifyConfigPath, configHeaders, ...input }) {
   return await parseAllHeaders({
     ...(headersFiles && { headersFiles: headersFiles.map(addFileFixtureDir) }),
     ...(netlifyConfigPath && { netlifyConfigPath: addConfigFixtureDir(netlifyConfigPath) }),
     configHeaders,
+    // Default `minimal` to `true` but still allows passing `undefined` to
+    // test the default value of that option
+    minimal: 'minimal' in input ? input.minimal : true,
   })
 }
 


### PR DESCRIPTION
Part of https://github.com/netlify/build/issues/2890

This adds a `forRegExp` property which allows consumers to check if a file path matches matches a specific header rule. 

This is mostly [taken from the CLI](https://github.com/netlify/cli/blob/219a105f21a9761875fc6d2124225055f8aa3cbd/src/utils/headers.js#L7) (which it will replace) but simplified and with several bug fixes (several cases were not matching production behavior).

This property is only added if the `minimal` option is `false`, which is the default value. Since adding properties in the return value would break some consumers (especially `@netlify/config`), this is a breaking change requiring those consumers to pass `minimal: true` instead.