### PR TITLE
fix: comma-separated lists should append a space

### DIFF
--- a/src/line_parser.js
+++ b/src/line_parser.js
@@ -99,7 +99,7 @@ const reduceLine = function ({ headers, errors }, { path, name, value }) {
   const previousHeaders = headers.slice(0, -1)
   const currentHeader = headers[headers.length - 1]
   const { values } = currentHeader
-  const newValue = values[name] === undefined ? value : `${values[name]},${value}`
+  const newValue = values[name] === undefined ? value : `${values[name]}, ${value}`
   const newHeaders = [...previousHeaders, { ...currentHeader, values: { ...values, [name]: newValue } }]
   return { headers: newHeaders, errors }
 }

--- a/src/normalize.js
+++ b/src/normalize.js
@@ -91,7 +91,7 @@ const normalizeRawValue = function (key, rawValue) {
   }
 
   if (Array.isArray(rawValue)) {
-    return rawValue.map((singleValue, index) => normalizeArrayItemValue(`${key}[${index}]`, singleValue)).join(',')
+    return rawValue.map((singleValue, index) => normalizeArrayItemValue(`${key}[${index}]`, singleValue)).join(', ')
   }
 
   throw new TypeError(`Header "${key}" value must be a string not: ${rawValue}`)
@@ -111,9 +111,9 @@ const normalizeRawValue = function (key, rawValue) {
 //   [[headers]]
 //   for = "/*"
 //     [headers.values]
-// 	   cache-control = "max-age=0,no-cache,no-store,must-revalidate"
+// 	   cache-control = "max-age=0, no-cache, no-store, must-revalidate"
 const normalizeMultipleValues = function (value) {
-  return value.split(MULTIPLE_VALUES_REGEXP).join(',')
+  return value.split(MULTIPLE_VALUES_REGEXP).join(', ')
 }
 
 const MULTIPLE_VALUES_REGEXP = /\s*,\s*/g

--- a/tests/line_parser.js
+++ b/tests/line_parser.js
@@ -80,7 +80,7 @@ each(
       input: {
         headersFiles: ['multiple_values'],
       },
-      output: [{ for: '/path', values: { test: 'one,two' } }],
+      output: [{ for: '/path', values: { test: 'one, two' } }],
     },
   ],
   ({ title }, { output, input }) => {

--- a/tests/netlify_config_parser.js
+++ b/tests/netlify_config_parser.js
@@ -52,14 +52,14 @@ each(
       input: {
         netlifyConfigPath: 'trim_value_array',
       },
-      output: [{ for: '/path', values: { test: 'one,two' } }],
+      output: [{ for: '/path', values: { test: 'one, two' } }],
     },
     {
       title: 'multiple_values',
       input: {
         netlifyConfigPath: 'multiple_values',
       },
-      output: [{ for: '/path', values: { test: 'one,two' } }],
+      output: [{ for: '/path', values: { test: 'one, two' } }],
     },
     {
       title: 'values_undefined',
@@ -73,7 +73,7 @@ each(
       input: {
         netlifyConfigPath: 'value_array',
       },
-      output: [{ for: '/path', values: { test: 'one,two' } }],
+      output: [{ for: '/path', values: { test: 'one, two' } }],
     },
     {
       title: 'for_path_no_slash',


### PR DESCRIPTION
In production, headers are joined with `", "` (comma+space) not with `","` (comma).