### PR TITLE
chore: add `escape-string-regexp` to `renovate.json5`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -7,6 +7,10 @@
     // Those cannot be upgraded until we drop support for Node 10 and
     // use ES modules
     {
+      matchPackageNames: ['escape-string-regexp'],
+      allowedVersions: '<5',
+    },
+    {
       matchPackageNames: ['is-plain-obj'],
       allowedVersions: '<4',
     },


### PR DESCRIPTION
The version 5 requires Node 12 and ES modules